### PR TITLE
Removes creationTimestamp from object meta for signing.

### DIFF
--- a/generatebundlefile/bundle.go
+++ b/generatebundlefile/bundle.go
@@ -23,30 +23,28 @@ var (
 // +kubebuilder:object:generate=false
 type BundleGenerateOpt func(config *BundleGenerate)
 
-// Used for generating yaml for generating a new crd sample file
-func NewBundleGenerate(bundleName string, opts ...BundleGenerateOpt) *BundleNoStatus {
-	clusterConfig := &BundleNoStatus{
-		PackageBundleNoTimestamp: &PackageBundleNoTimestamp{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       api.PackageBundleKind,
-				APIVersion: SchemeBuilder.GroupVersion.String(),
-			},
-			ObjectMetaNoTimestamp: ObjectMetaNoTimestamp{
-				Name:      bundleName,
-				Namespace: api.PackageNamespace,
-			},
-			Spec: api.PackageBundleSpec{
-				Packages: []api.BundlePackage{
-					{
-						Name: "sample-package",
-						Source: api.BundlePackageSource{
-							Registry:   "sample-Registry",
-							Repository: "sample-Repository",
-							Versions: []api.SourceVersion{
-								{
-									Name:   "v0.0",
-									Digest: "sha256:da25f5fdff88c259bb2ce7c0f1e9edddaf102dc4fb9cf5159ad6b902b5194e66",
-								},
+// Used for generating YAML for generating a new sample CRD file.
+func NewBundleGenerate(bundleName string, opts ...BundleGenerateOpt) *api.PackageBundle {
+	return &api.PackageBundle{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       api.PackageBundleKind,
+			APIVersion: SchemeBuilder.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bundleName,
+			Namespace: api.PackageNamespace,
+		},
+		Spec: api.PackageBundleSpec{
+			Packages: []api.BundlePackage{
+				{
+					Name: "sample-package",
+					Source: api.BundlePackageSource{
+						Registry:   "sample-Registry",
+						Repository: "sample-Repository",
+						Versions: []api.SourceVersion{
+							{
+								Name:   "v0.0",
+								Digest: "sha256:da25f5fdff88c259bb2ce7c0f1e9edddaf102dc4fb9cf5159ad6b902b5194e66",
 							},
 						},
 					},
@@ -54,8 +52,6 @@ func NewBundleGenerate(bundleName string, opts ...BundleGenerateOpt) *BundleNoSt
 			},
 		},
 	}
-	clusterConfig.Status = nil
-	return clusterConfig
 }
 
 // NewPackageFromInput finds the SHA tags for any images in your BundlePackage
@@ -83,34 +79,29 @@ func (projects Project) NewPackageFromInput() (*api.BundlePackage, error) {
 }
 
 // AddMetadata adds the corresponding metadata to the crd files.
-func AddMetadata(s api.PackageBundleSpec, name string) BundleNoStatus {
-	bundleName := name
-	b := &BundleNoStatus{
-		PackageBundleNoTimestamp: &PackageBundleNoTimestamp{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       api.PackageBundleKind,
-				APIVersion: SchemeBuilder.GroupVersion.String(),
-			},
-			ObjectMetaNoTimestamp: ObjectMetaNoTimestamp{
-				Name:      bundleName,
-				Namespace: api.PackageNamespace,
-			},
-			Spec: s,
+func AddMetadata(s api.PackageBundleSpec, name string) *api.PackageBundle {
+	return &api.PackageBundle{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       api.PackageBundleKind,
+			APIVersion: SchemeBuilder.GroupVersion.String(),
 		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: api.PackageNamespace,
+		},
+		Spec: s,
 	}
-	b.Status = nil
-	return *b
 }
 
-func IfSignature(bundle *BundleNoStatus) (bool, error) {
-	annotations := bundle.ObjectMetaNoTimestamp.Annotations
+func IfSignature(bundle *api.PackageBundle) (bool, error) {
+	annotations := bundle.Annotations
 	if annotations != nil {
 		return true, nil
 	}
 	return false, nil
 }
 
-func AddSignature(bundle *BundleNoStatus, signature string) (*BundleNoStatus, error) {
+func AddSignature(bundle *api.PackageBundle, signature string) (*api.PackageBundle, error) {
 	annotations := map[string]string{}
 	if signature == "" || bundle == nil {
 		return nil, fmt.Errorf("Error adding signature to bundle, empty signature, or bundle entry\n")
@@ -118,11 +109,11 @@ func AddSignature(bundle *BundleNoStatus, signature string) (*BundleNoStatus, er
 	annotations = map[string]string{
 		sig.FullSignatureAnnotation: signature,
 	}
-	bundle.ObjectMetaNoTimestamp.Annotations = annotations
+	bundle.Annotations = annotations
 	return bundle, nil
 }
 
-func CheckSignature(bundle *BundleNoStatus, signature string) (bool, error) {
+func CheckSignature(bundle *api.PackageBundle, signature string) (bool, error) {
 	if signature == "" || bundle == nil {
 		return false, fmt.Errorf("either signature or bundle is missing, but are required")
 	}
@@ -130,20 +121,25 @@ func CheckSignature(bundle *BundleNoStatus, signature string) (bool, error) {
 		sig.FullSignatureAnnotation: signature,
 	}
 	//  If current signature on file isn't at the --signature input return false, otherwsie true
-	if annotations[sig.FullSignatureAnnotation] != bundle.ObjectMetaNoTimestamp.Annotations[sig.FullSignatureAnnotation] {
+	if annotations[sig.FullSignatureAnnotation] != bundle.Annotations[sig.FullSignatureAnnotation] {
 		return false, fmt.Errorf("A signature already exists on the input file signatue")
 	}
 	return true, nil
 }
 
-// MarshalBundleSpec will create yaml objects from bundlespecs TODO look into https://pkg.go.dev/encoding/json#example-package-CustomMarshalJSON
-func MarshalBundleSpec(bundle BundleNoStatus) ([]byte, error) {
-	marshallables := []interface{}{bundle}
+// MarshalPackageBundle will create yaml objects from bundlespecs.
+//
+// TODO look into
+// https://pkg.go.dev/encoding/json#example-package-CustomMarshalJSON
+func MarshalPackageBundle(bundle *api.PackageBundle) ([]byte, error) {
+	marshallables := []interface{}{
+		newSigningPackageBundle(bundle),
+	}
 	resources := make([][]byte, len(marshallables))
 	for _, marshallable := range marshallables {
 		resource, err := yaml.Marshal(marshallable)
 		if err != nil {
-			return nil, fmt.Errorf("marshalling resource for bundle: %w", err)
+			return nil, fmt.Errorf("marshaling package bundle: %w", err)
 		}
 		resources = append(resources, resource)
 	}
@@ -151,8 +147,8 @@ func MarshalBundleSpec(bundle BundleNoStatus) ([]byte, error) {
 }
 
 // WriteBundleConfig writes the yaml objects to files in your defined dir
-func WriteBundleConfig(bundle BundleNoStatus, writer FileWriter) error {
-	crdContent, err := MarshalBundleSpec(bundle)
+func WriteBundleConfig(bundle *api.PackageBundle, writer FileWriter) error {
+	crdContent, err := MarshalPackageBundle(bundle)
 	if err != nil {
 		return err
 	}

--- a/generatebundlefile/bundle_types.go
+++ b/generatebundlefile/bundle_types.go
@@ -50,9 +50,42 @@ type PackageBundleNoTimestamp struct {
 	Status api.PackageBundleStatus `json:"status,omitempty"`
 }
 
-type BundleNoStatus struct {
-	*PackageBundleNoTimestamp
+// SigningPackageBundle removes fields that shouldn't be included when signing.
+type SigningPackageBundle struct {
+	*api.PackageBundle
+
+	// The fields below are to be modified or removed before signing.
+
+	// SigningObjectMeta removes fields that shouldn't be included when signing.
+	*SigningObjectMeta `json:"metadata,omitempty"`
+
+	// Status isn't relevant to a digital signature.
 	Status interface{} `json:"status,omitempty"`
+}
+
+func newSigningPackageBundle(bundle *api.PackageBundle) *SigningPackageBundle {
+	return &SigningPackageBundle{
+		PackageBundle:     bundle,
+		SigningObjectMeta: newSigningObjectMeta(&bundle.ObjectMeta),
+		Status:            nil,
+	}
+}
+
+// SigningObjectMeta removes fields that shouldn't be included when signing.
+type SigningObjectMeta struct {
+	*metav1.ObjectMeta
+
+	// The fields below are to be removed before signing.
+
+	// CreationTimestamp isn't relevant to a digital signature.
+	CreationTimestamp interface{} `json:"creationTimestamp,omitempty"`
+}
+
+func newSigningObjectMeta(meta *metav1.ObjectMeta) *SigningObjectMeta {
+	return &SigningObjectMeta{
+		ObjectMeta:        meta,
+		CreationTimestamp: nil,
+	}
 }
 
 // Types for input file format

--- a/generatebundlefile/input.go
+++ b/generatebundlefile/input.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -58,9 +59,8 @@ func (inputConfig *Input) ValidateInputNotEmpty() error {
 	return nil
 }
 
-func ValidateBundle(fileName string) (*BundleNoStatus, error) {
-	bundle := &BundleNoStatus{}
-	err := ParseBundle(fileName, bundle)
+func ValidateBundle(fileName string) (*api.PackageBundle, error) {
+	bundle, err := ParseBundle(fileName)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func ValidateBundle(fileName string) (*BundleNoStatus, error) {
 	return bundle, err
 }
 
-func ValidateBundleContent(bundle *BundleNoStatus) error {
+func ValidateBundleContent(bundle *api.PackageBundle) error {
 	for _, v := range bundleValidations {
 		if err := v(bundle); err != nil {
 			return err
@@ -80,11 +80,11 @@ func ValidateBundleContent(bundle *BundleNoStatus) error {
 	return nil
 }
 
-var bundleValidations = []func(*BundleNoStatus) error{
+var bundleValidations = []func(*api.PackageBundle) error{
 	validateBundleName,
 }
 
-func validateBundleName(bundle *BundleNoStatus) error {
+func validateBundleName(bundle *api.PackageBundle) error {
 	err := ValidateBundleNoSignature(bundle)
 	if err != nil {
 		return err
@@ -92,7 +92,7 @@ func validateBundleName(bundle *BundleNoStatus) error {
 	return nil
 }
 
-func ValidateBundleNoSignature(bundle *BundleNoStatus) error {
+func ValidateBundleNoSignature(bundle *api.PackageBundle) error {
 	// Check if Projects are listed
 	if len(bundle.Spec.Packages) < 1 {
 		return fmt.Errorf("Should use non-empty list of projects for input")
@@ -100,22 +100,23 @@ func ValidateBundleNoSignature(bundle *BundleNoStatus) error {
 	return nil
 }
 
-func ParseBundle(fileName string, bundle *BundleNoStatus) error {
-	content, err := ioutil.ReadFile(filepath.Clean(fileName))
+func ParseBundle(filename string) (*api.PackageBundle, error) {
+	content, err := ioutil.ReadFile(filepath.Clean(filename))
 	if err != nil {
-		return fmt.Errorf("unable to read file due to: %v", err)
+		return nil, fmt.Errorf("reading package bundle file %q: %w", filename, err)
 	}
-	for _, c := range strings.Split(string(content), YamlSeparator) {
-		if err = yaml.Unmarshal([]byte(c), bundle); err != nil {
-			return fmt.Errorf("unable to parse %s\nyaml: %s\n %v", fileName, string(c), err)
-		}
-		err = yaml.UnmarshalStrict([]byte(c), bundle)
+
+	for _, doc := range bytes.Split(content, []byte(YamlSeparator)) {
+		bundle := &api.PackageBundle{}
+		err = yaml.UnmarshalStrict(doc, bundle)
 		if err != nil {
-			return fmt.Errorf("unable to UnmarshalStrict %v\nyaml: %s\n %v", bundle, string(c), err)
+			return nil, fmt.Errorf("unmarshaling package bundle from %q: %w",
+				filename, err)
 		}
-		return nil
+		return bundle, nil
 	}
-	return fmt.Errorf("cluster spec file %s is invalid or does not contain kind %v", fileName, bundle)
+
+	return nil, fmt.Errorf("invalid package bundle file %q", filename)
 }
 
 func ParseInputConfig(fileName string, inputConfig *Input) error {

--- a/generatebundlefile/main.go
+++ b/generatebundlefile/main.go
@@ -30,7 +30,7 @@ func main() {
 	// If using --generatesample flag we skip the yaml input portion
 	if o.generateSample {
 		sample := NewBundleGenerate("generatesample")
-		err := WriteBundleConfig(*sample, outputPath)
+		err := WriteBundleConfig(sample, outputPath)
 		if err != nil {
 			BundleLog.Error(err, "Unable to create CRD skaffolding from generatesample command")
 		}
@@ -132,7 +132,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	//One input file, and a --signature input
+	// One input file, and a --signature input
 	if o.signature != "" && len(files) == 1 {
 		BundleLog.Info("In Progress: Checking Bundles for Signatures")
 		bundle, err := ValidateBundle(files[0])
@@ -156,7 +156,7 @@ func main() {
 				os.Exit(1)
 			}
 		}
-		err = WriteBundleConfig(*bundle, outputPath)
+		err = WriteBundleConfig(bundle, outputPath)
 		if err != nil {
 			BundleLog.Error(err, "Unable to write Bundle")
 			os.Exit(1)


### PR DESCRIPTION
By shadowing the fields to be removed with nil pointer values, the
YAML library can omit those fields. The upstream types don't use
pointers, and so the YAML library outputs zero values for those
fields.

The fields are removed to maintain reproducible signature
verification.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
